### PR TITLE
30 random remaining tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v1.12.0
+
+2024-01-13
+
+-   only allow one registration for now: the first admin user until there's a need for more public-facing registrations (additional users can be created via user create endpoint)
+-   add app configured default per_page and max_per_page
+-   add status to access node updates, make all parameters optional
+-   clear device node and user assignments on device archive
+-   add filtering device list by user id
+-   set assigned access cards to inactive when user updated to not active
+-   unassign cards when archiving user
+-   update access node statuses to fit with nodes in use now
+
 ## v1.11.0
 
 2023-12-01

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -44,7 +44,20 @@ def register():
     if user:
         return jsonify(message="username already in use"), 401
 
-    # TODO: Better improve this so this doesn't get spammed with new users.
+    # TEMPORARY
+    # Only allow one/the first user register as an admin until there's
+    # a need to allow multiple users e.g. members to register. For now
+    # there's nothing in place to validate or need registrations, yet
+    # it's good to have a unique user/pass for the first admin.
+    user = User.query.first()
+    if user:
+        return jsonify(
+            message="A user is already registered. For now until there's a \
+need, only the first user can register. Create new users \
+instead in admin."
+            ), 401
+    # END TEMPORARY
+
     # Need captcha, email verification, etc.
     new_user = User(
             username=username,

--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,3 @@
-# TODO: log errors to file
-
 import os
 from datetime import timedelta
 from flask import Flask
@@ -28,6 +26,9 @@ migrate = Migrate(app, db)
 
 # this is needed for defs like role_required() to work
 app.app_context().push()
+
+app.config['DEFAULT_PER_PAGE'] = 20
+app.config['DEFAULT_MAX_PER_PAGE'] = 100
 
 
 @jwt.token_in_blocklist_loader

--- a/app/model_enums.py
+++ b/app/model_enums.py
@@ -1,8 +1,6 @@
 import enum
 
 
-# TODO: Discuss: This assumes single role per user. Should we consider a list
-# of roles per user? (and how would we go about that if relevant?)
 class UserRoleEnum(str, enum.Enum):
     UNVERIFIED = 'unverified'
     USER = 'user'
@@ -43,9 +41,18 @@ class UserAccessActionEnum(str, enum.Enum):
 
 class AccessNodeStatusEnum(str, enum.Enum):
     OFFLINE = 'offline'
-    AVAILABLE = 'available'
+    # 0 waiting for card read, tool is off
+    IDLE = 'idle'
+    # 1 card read, validated, tool is allowed to be turned on
+    ENABLED = 'enabled'
+    # 2 tool is turned on (if we can track for specific machine)
     IN_USE = 'in use'
+    # 3 node error
     ERROR = 'error'
+    # 4 not in use currently e.g. long-run 3D printing job is finished
+    END_OF_RUN = 'end of run'
+    # -1 machine is locked e.g. makerspace emergency, not common
+    LOCKDOWN = 'lockdown'
     ARCHIVED = 'archived'
 
 
@@ -57,8 +64,6 @@ class AccessNodeScanActionEnum(str, enum.Enum):
 
 
 class DeviceTypeEnum(str, enum.Enum):
-    # TODO: "machine" may be too generalized, make a new enum value for each
-    # unique configuration a tesla node needs to work through
     MACHINE = 'machine'
     DOOR = 'door'
 

--- a/app/models.py
+++ b/app/models.py
@@ -13,7 +13,6 @@ def uuid_str():
     return str(uuid.uuid4())
 
 
-# TODO: Cleanup script needed for tokens older than x days
 class TokenBlocklist(db.Model):
     id = db.Column(
         db.String(36),

--- a/app/query/access_card_edit_logs.py
+++ b/app/query/access_card_edit_logs.py
@@ -1,4 +1,5 @@
 from ..app import db
+from ..app import app
 from ..models import User, AccessCardLog, AccessCardStatusEnum, \
     UserEmergeAccessLevelEnum
 from .device_access_logs import validate_date
@@ -7,7 +8,7 @@ from sqlalchemy.orm import aliased
 
 default_params = {
     'page': 1,
-    'per_page': 1000,
+    'per_page': app.config['DEFAULT_PER_PAGE'],
     # optional user id string
     'assigned_to_user_id': None,
     # optional user id string
@@ -136,7 +137,7 @@ def access_card_edit_logs(params):
         .paginate(
             page=page,
             per_page=per_page,
-            max_per_page=10000,
+            max_per_page=app.config['DEFAULT_MAX_PER_PAGE'],
             error_out=False
         )
 

--- a/app/query/device_access_logs.py
+++ b/app/query/device_access_logs.py
@@ -1,4 +1,5 @@
 from ..app import db
+from ..app import app
 from ..models import Device, User, AccessNodeLog, AccessNodeScanActionEnum
 from datetime import datetime
 
@@ -14,7 +15,7 @@ def validate_date(date_string):
 
 default_params = {
     'page': 1,
-    'per_page': 1000,
+    'per_page': app.config['DEFAULT_PER_PAGE'],
     # optional user id string
     'user_id': None,
     # optional access card id string
@@ -123,7 +124,7 @@ def device_access_logs(params):
         .paginate(
             page=page,
             per_page=per_page,
-            max_per_page=10000,
+            max_per_page=app.config['DEFAULT_MAX_PER_PAGE'],
             error_out=False
         )
 

--- a/app/query/user_access_logs.py
+++ b/app/query/user_access_logs.py
@@ -1,4 +1,5 @@
 from ..app import db
+from ..app import app
 from ..models import User, UserAccessLog
 from ..model_enums import UserAccessActionEnum
 from .device_access_logs import validate_date
@@ -6,7 +7,7 @@ from .device_access_logs import validate_date
 
 default_params = {
     'page': 1,
-    'per_page': 1000,
+    'per_page': app.config['DEFAULT_PER_PAGE'],
     # updated_by_user_id
     'user_id': None,
     # optional UserAccessActionEnum
@@ -86,7 +87,7 @@ def user_access_logs(params):
         .paginate(
             page=page,
             per_page=per_page,
-            max_per_page=10000,
+            max_per_page=app.config['DEFAULT_MAX_PER_PAGE'],
             error_out=False
         )
 

--- a/app/query/user_edit_logs.py
+++ b/app/query/user_edit_logs.py
@@ -1,4 +1,5 @@
 from ..app import db
+from ..app import app
 from ..models import User, UserEditLog
 from ..model_enums import UserRoleEnum, UserStatusEnum, \
     UserEmergeAccessLevelEnum
@@ -8,7 +9,7 @@ from sqlalchemy.orm import aliased
 
 default_params = {
     'page': 1,
-    'per_page': 1000,
+    'per_page': app.config['DEFAULT_PER_PAGE'],
     # updated_by_user_id
     'user_id': None,
     # optional UserRoleEnum
@@ -138,7 +139,7 @@ def user_edit_logs(params):
         .paginate(
             page=page,
             per_page=per_page,
-            max_per_page=10000,
+            max_per_page=app.config['DEFAULT_MAX_PER_PAGE'],
             error_out=False
         )
 


### PR DESCRIPTION
add status to access node updates, make all parameters optional and updates when set

clear device node and user assignments on archive, filter device list by user id

set assigned access cards to inactive when user not active, unassign cards when archiving user

update access node statuses to fit with nodes in use now

only allow one registered user, the first admin user, for now